### PR TITLE
Make the script working

### DIFF
--- a/Chapter 2 Files/GPO Deployment/update.bat
+++ b/Chapter 2 Files/GPO Deployment/update.bat
@@ -1,15 +1,18 @@
-@echo off
+::@echo off
 :: Credits: Credit to Ryan Watson (@gentlemanwatson) and Syspanda.com from which this script was adapted from.
+:: Changed by @S0xbad1dea
 
 
 
+::This doesn't work at the moment, because white spaces are put in the file. This corrupts the path for later usage
+::(wmic computersystem get domain | findstr /v Domain | findstr /r /v "^$") > fqdn.txt
+::set /p FQDN=<fqdn.txt
+::echo %FQDN%
 
+SET FQDN=<YOUR_DOMAIN>
 
-(wmic computersystem get domain | findstr /v Domain | findstr /r /v "^$") > fqdn.txt
-set /p FQDN=<fqdn.txt
-echo %FQDN%
-
-SET SYSMONDIR=C:\windows\sysmon
+::Change the SYSMONDIR if you want to,but it will also works on C:\Windows. If you put sysmon outside C:\Windows, it will copy itself there.
+SET SYSMONDIR=C:\windows
 SET SYSMONBIN=Sysmon64.exe
 SET SYSMONCONF=sysmon.xml
 SET SIGCHECK=sigcheck64.exe
@@ -19,7 +22,9 @@ SET GLBSYSMONBIN=\\%FQDN%\sysvol\%FQDN%\Sysmon\%SYSMONBIN%
 SET GLBSYSMONCONFIG=\\%FQDN%\sysvol\%FQDN%\Sysmon\%SYSMONCONF%
 SET GLBSIGCHECK=\\%FQDN%\sysvol\%FQDN%\Sysmon\%SIGCHECK%
 
-
+IF Not EXIST %SYSMONDIR% (
+mkdir %SYSMONDIR%
+)
 :: Is Sysmon running  
 sc query "Sysmon64" | find "STATE" | find "RUNNING"
 If "%ERRORLEVEL%" NEQ "0" (
@@ -44,14 +49,11 @@ goto checkversion
 
   
 :installsysmon
-IF Not EXIST %SYSMONDIR% (
-mkdir %SYSMONDIR%
-)
 xcopy %GLBSYSMONBIN% %SYSMONDIR% /y
 xcopy %GLBSYSMONCONFIG% %SYSMONDIR% /y
 xcopy %GLBSIGCHECK% %SYSMONDIR% /y
 chdir %SYSMONDIR%
-%SYSMONBIN% -i %SYSMONCONFIG% -accepteula -h md5,sha256 -n -l
+%SYSMONBIN% -i %SYSMONCONF% -accepteula -h sha1,d5,sha256,imphash -n -l
 sc config Sysmon64 start= auto
 goto :checkversion
 
@@ -60,8 +62,12 @@ goto :checkversion
 :: Check if sysmon64.exe matches the hash of the central version 
 :checkversion
 chdir %SYSMONDIR%
-IF EXIST *.txt DEL /F *.txt
-(sigcheck64.exe -n -nobanner /accepteula Sysmon64.exe) > %SYSMONDIR%\runningver.txt
+IF EXIST runningver.txt DEL /F runningver.txt
+IF EXIST latestver.txt DEL /F latestver.txt
+::Add additional check because of manual installed Sysmon. You can jump here if Sysmon was installed manually and running
+IF NOT EXIST %SIGCHECK% (
+xcopy %GLBSIGCHECK% %SYSMONDIR% /y)
+(sigcheck64.exe -n -nobanner /accepteula %SYSMONBIN%) > %SYSMONDIR%\runningver.txt
 (sigcheck64.exe -n -nobanner /accepteula %GLBSYSMONBIN%) > %SYSMONDIR%\latestver.txt
 set /p runningver=<%SYSMONDIR%\runningver.txt
 set /p latestver=<%SYSMONDIR%\latestver.txt
@@ -75,17 +81,28 @@ goto updateconfig
 
 :updateconfig
 chdir %SYSMONDIR%
-IF EXIST *.txt DEL /F *.txt
-(sigcheck64.exe -h -nobanner /accepteula sysmon.xml) > %SYSMONDIR%\runningconfver.txt
-(sigcheck64.exe -h -nobanner /accepteula %GLBSYSMONCONFIG%) > %SYSMONDIR%\latestconfver.txt
-set /p runningver=<%SYSMONDIR%\runningconfver.txt
-set /p latestver=<%SYSMONDIR%\latestconfver.txt
+IF EXIST runningconfver.txt DEL /F runningconfver.txt
+IF EXIST latestconfver.txt DEL /F latestconfver.txt
+if NOT EXIST %SIGCHECK% (
+xcopy %GLBSIGCHECK% %SYSMONDIR% /y)
+::Added -c for the comparison, enables us to compare hashes
+(sigcheck64.exe -h -c -nobanner /accepteula %SYSMONCONF%) > %SYSMONDIR%\runningconfver.txt
+(sigcheck64.exe -h -c -nobanner /accepteula %GLBSYSMONCONFIG%) > %SYSMONDIR%\latestconfver.txt
+::Looks for the 11th token in the csv of sigcheck. This is the MD5 hash. 12th token is SHA1, 15th is SHA2
+for /F "delims=, tokens=11" %%h in (runningconfver.txt) DO (set runningconfver=%%h)
+for /F "delims=, tokens=11" %%h in (latestconfver.txt) DO (set latestconfver=%%h)
+::The following commands are not usful because they are comparing only the first line, which includes the path of the checked file. And this is always not eqal.
+::set /p runningconfver=<%SYSMONDIR%\runningconfver.txt
+::set /p latestconfver=<%SYSMONDIR%\latestconfver.txt
 If "%runningconfver%" NEQ "%latestconfver%" (
-xcopy %GLBSYSMONCONFIG% %SYSMONCONFIG% /y
+xcopy %GLBSYSMONCONFIG% %SYSMONDIR% /y
 chdir %SYSMONDIR%
-%SYSMONBIN% -c %SYSMONCONFIG%
+(%SYSMONBIN% -c %SYSMONCONF%)
+
+)
 EXIT /B 0
 
 :uninstallsysmon
+chdir %SYSMONDIR%
 %SYSMONBIN% -u
 goto installsysmon


### PR DESCRIPTION
The Domain check with wmic doesn't work, because whitespaces are also included, which breaks the path to your Sysvol. So set your domain in the script manually. Search for the term <YOUR_DOMAIN>.
SET SYSMONDIR was changed to C:\Windows. No specific reason, but  when you install Sysmon manually from a folder outside C:\Windows, it will install itself to C:\Windows.
If you don't use C:\Windows, it will check if the new Sysmon folder exists.

:installsysmon
I've added additional hashes as installation parameter, but depending on your Sysmon config will this be overwritten.

:checkversion
If Sysmon was installed manually and not with the script, sigcheck64 may be missing. Added an additional check if it exists.

:updateconfig
If Sysmon was installed manually and not with the script, sigcheck64 may be missing. Added an additional check if it exists.
Also added a hash comparison of the Sysmon configs. The old way with set /p variable=<file didn't work, because it only reads the first line, which is everytime the path of the file and so, in the end, this check will never work, because file pathes are only compared.

:uninstallsysmon
Added chdir to the Sysmon path.