### PR TITLE
Docker web proxy instructions

### DIFF
--- a/docs/chapter3-easy.md
+++ b/docs/chapter3-easy.md
@@ -41,7 +41,7 @@ If the ELK stack is being deployed behind a web proxy, and Docker isn't configur
 ```
 sudo mkdir -p /etc/systemd/system/docker.service.d
 ```
-2) Create a file named /etc/systemd/system/docker.service.d/http-proxy.conf that adds the HTTP_PROXY environment variable:
+2) Create a file named /etc/systemd/system/docker.service.d/http-proxy.conf that adds the HTTP_PROXY and HTTPS_PROXY environment variables (keep/delete as required for your environment):
 ```
 [Service]
 Environment="HTTP_PROXY=http://[proxy address or IP]:[proxy port]"
@@ -51,6 +51,8 @@ Environment="HTTPS_PROXY=https://[proxy address or IP]:[proxy port]"
 ```
 sudo systemctl daemon-reload
 ```
+
+Check the [official Docker documentation](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy) for this process, including details on how to bypass the proxy if you have internal image registries which need to be reachable from this host.
 
 ## 3.2 Install LME the easy way using our script
 

--- a/docs/chapter3-easy.md
+++ b/docs/chapter3-easy.md
@@ -34,6 +34,23 @@ You will need a linux box for this portion, **The deploy script is only tested o
 ### 3.1.1 Firewall Rules
 You will need port 5044 open for the event collector to send data into the database (on the Linux server), To be able to access the web interface you will need to have firewall rules in place to allow access to port 443 (HTTPS) on the Linux server.
 
+### 3.1.2 Web Proxy Settings
+If the ELK stack is being deployed behind a web proxy, and Docker isn't configured to use the proxy, the deploy script can hang without completing due to docker being unable to pull the required images. To configure docker to use the web proxy in your environment, do the following before running the deployment script.
+
+1) Create a systemd drop-in directory for the docker service:
+```
+sudo mkdir -p /etc/systemd/system/docker.service.d
+```
+2) Create a file named /etc/systemd/system/docker.service.d/http-proxy.conf that adds the HTTP_PROXY environment variable:
+```
+[Service]
+Environment="HTTP_PROXY=http://[proxy address or IP]:[proxy port]"
+Environment="HTTPS_PROXY=https://[proxy address or IP]:[proxy port]"
+```
+3) Reload the service daemon:
+```
+sudo systemctl daemon-reload
+```
 
 ## 3.2 Install LME the easy way using our script
 


### PR DESCRIPTION
Added instructions for passing web proxy config to Docker to allow images to be pulled from behind a web proxy.