### PR TITLE
Swapped around comment regarding event id 7000 and 7045 

### DIFF
--- a/Chapter 1 Files/lme_wec_config.xml
+++ b/Chapter 1 Files/lme_wec_config.xml
@@ -50,7 +50,7 @@
     <Select Path="System">*[System[Provider[@Name='Microsoft-Windows-Kernel-General'] and (EventID=12 or EventID=13)]]</Select>
   </Query>
   <Query Id="5" Path="System">
-    <!-- Service Install (7000), service start failure (7045), new service (4697) -->
+    <!-- Service start failure (7000), service install (7045), new service (4697) -->
     <Select Path="System">*[System[Provider[@Name='Service Control Manager'] and (EventID = 7000 or EventID=7045)]]</Select>
 <Select Path="Security">*[System[(EventID=4697)]]</Select>
   </Query>


### PR DESCRIPTION
Fixed comment regarding the meaning of Event ID 7000 and 7045:
Event ID [7000](https://social.technet.microsoft.com/wiki/contents/articles/13506.event-id-7000-service-start-failure.aspx) corresponds to Service start failure 
Event ID [7045](https://www.manageengine.com/products/active-directory-audit/kb/system-events/event-id-7045.html) corresponds to Service installed 