### PR TITLE
PublicBaseURL hotfix

### DIFF
--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -798,7 +798,7 @@ function update() {
       # copy publicbaseurl
       baseurl_from_conf="$(grep -P -o "(?<=SERVER_PUBLICBASEURL: ).*" /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml.old)"
       #update config with publicbaseurl
-      if [ -n "$baseurl_from_conf" ]; then
+      if [ -n "$baseurl_from_conf" ] && [ "$baseurl_from_conf" != "insertpublicurlhere" ]; then
         sed -i "s,insertpublicurlhere,$baseurl_from_conf,g" /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
       elif [ -n "$hostname" ]; then
         sed -i "s/insertpublicurlhere/https:\/\/$hostname/g" /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml


### PR DESCRIPTION
A hotfix for the PublicBaseURL parameter, where the update script runs an older version and inserts the placeholder value into a live config. Running the update function again once your local files are fully updated from the git repo, or waiting for it to run automatically twice, should remove the placeholder value and replace it with the correct value from the LME config.

Referenced in #116 - this issue is caused by the update mechanism triggering an update of the docker compose file, but the cached version of the update script not properly containing the handling to deal with this during an initial update.

If you are affected by this issue then doing a git pull before triggering the update script again should now resolve it:

```
sudo git -C /opt/lme/ pull
sudo /opt/lme/Chapter\ 3\ Files/deploy.sh update
```